### PR TITLE
fix css regressions after adding reset.css

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -38,8 +38,12 @@ body {
   font-size: 1em;
   float: left;
   margin-bottom: 0.5rem;
-  padding: 1em 0.3em 1em 0.3em;
+  padding: 1em 0.3em 2em 0.3em;
   width: fit-content;
+}
+
+.winlossp {
+  margin-bottom: 1em;
 }
 
 #crystalParentId {

--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@
     <div id="helpId">help text goes here</div>
     <div id="targetValueId">targetValue</div>
     <div id="winloss">
-      <p>Wins: <span id="winsId">wins</span></p>
-      <p>Losses: <span id="lossesId">losses</span></p>
+      <p class="winlossp">Wins: <span id="winsId">wins</span></p>
+      <p class="winlossp">Losses: <span id="lossesId">losses</span></p>
     </div>
     <div id="crystalParentId"></div>
     <div id="scoreLabel">Your total score is:</div>


### PR DESCRIPTION
The win/losses styling lacked spacing between paragraphs.

Fix it: https://www.youtube.com/watch?v=yo3uxqwTxk0