### PR TITLE
avoid code duplication by calling superclass method from overriding s…

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Controller.prototype.getCrystalCallback = function() {
   - [Controller](https://github.com/zenglenn42/utbc2019-hw-04-crystal-collector/blob/e98776d2cf56c8e5af537e9af54434f9aa04d603/assets/js/controller.js#L7)
     - This mediates data flow between the user interface and game objects.
 
+## Implementation Blockers
+
+### Chrome's Live Evaluation of Objects
+
 Surprisingly little integration debugging was required, but my world was rocked a bit during unit test of the CrystalCollector model. It looks like chrome's console performs a live evaluation of object content.
 
 This threw me off because I would [newly instantiate the game object](https://github.com/zenglenn42/utbc2019-hw-04-crystal-collector/blob/541ed9b7b7ef42ae4a29acb54c766d87d8e0f471/assets/js/model.js#L141), dump it to the console, mutate the object, then console log again. But drilling down into both before-and-after objects within the inspector yielded only the /mutated/ object values in both cases!
@@ -70,3 +74,64 @@ This threw me off because I would [newly instantiate the game object](https://gi
 The lesson is that console log does not necessarily reflect an object's history of change over time. I need to dig into this more as I'm unsure if this relates more to the shared aspect of an object's prototype area across all instances versus some tooling behaviour unique to chrome's inspector.
 
 Setting a breakpoint before mutation reassured me that the object did in fact transition from it's initial value to it's mutated value as desired.
+
+### Hidden Superclass Method
+
+Early on, during integration testing of the controller and the game model, I noticed the accumulated score was not resetting to 0 between rounds of play. I could have sworn I'd taken care to do that somewhere, and sure enough, here it was:
+
+```javascript
+Game.prototype.reset = function() {
+  this.score = 0;
+  this.state = "playing";
+};
+```
+
+However, since I'd subclassed the CrystalController object from Game, I had overridden the reset method with something that only knew about re-randomizing crystals (and not resetting the score and state):
+
+```javascript
+CrystalCollector.prototype.reset = function() {
+  for (let index in this.crystals) {
+    this.crystals[index].reset();
+  }
+  this.targetValue = this.getRandomValue();
+};
+```
+
+I naively assumed the super class' reset method would get magically called behind the scenes. This did not happen. Not being terribly familiar with inheritance in javascript, I opted to recreate the contents of the super class' reset in the overriding method:
+
+```javascript
+CrystalCollector.prototype.reset = function() {
+  this.score = 0; // :-|  Works, but I'm duplicating code.
+  this.state = "playing"; // :-|
+  for (let index in this.crystals) {
+    this.crystals[index].reset();
+  }
+  this.targetValue = this.getRandomValue();
+};
+```
+
+This works, however, the code duplication rankles me since I /know/ other languages have idioms for invoking a super class method from the subclass. It turns out javascript has a couple options here depending upon a traditional style or a more modern ES6 style.
+
+Apparently, I'm using a more traditional style of inheritance which I glommed onto from Marc Wandschneider's book, "Learning Node.js", published in 2017. In that style, it would be better to do this:
+
+```javascript
+CrystalCollector.prototype.reset = function() {
+  Game.prototype.reset.call(this); // :-) call superclass reset() method
+  for (let index in this.crystals) {
+    this.crystals[index].reset();
+  }
+  this.targetValue = this.getRandomValue();
+};
+```
+
+The more modern (ES6) syntax replaces the verbose call to Game.prototype.reset.call(this) with:
+
+```javascript
+super.reset();
+```
+
+That seems enough of a cognitive win to abandon traditional syntax altogether. I haven't decided which camp I'm in yet. I'll play with both styles.
+
+I sense factions within the JS community itself with some aligning with tradition since it is more obvious what is actually going on behind the scenes. JS luminaries like Douglas Crockford, author of "JavaScript: The Good Parts", seems to eschew more modern syntactic sugar that would seek to make JS's prototypal inheritance (where objects inherit from other objects) look 'pseudo classical' in the surface style of java's class-based inheritance. He actually argues that prototype inheritance is more expressive than java's flavor and should not be slathered over with java-like syntax out of a lack of confidence.
+
+Personally, I suspect once I have the low-level fundamentals down, I'll enjoy the cleaner syntax of ES6 inheritance.

--- a/assets/js/model.js
+++ b/assets/js/model.js
@@ -26,8 +26,6 @@ Game.prototype.getScore = function() {
     return this.score;
 }
 Game.prototype.reset = function() {
-    this.losses = 0;
-    this.wins = 0;
     this.score = 0;
     this.state = "playing";
 }
@@ -70,8 +68,7 @@ CrystalCollector.prototype.getTargetValue = function() {
     return this.targetValue;
 }
 CrystalCollector.prototype.reset = function() {
-    this.score = 0;
-    this.state = "playing";
+    Game.prototype.reset.call(this);    // call supercalss reset()
     for (let index in this.crystals) {
         this.crystals[index].reset();
     }


### PR DESCRIPTION
…ubclass method

I was duplicating code in the CrystalCollector.reset() method.  But js, like other languages,
provides the option of invoking a superclass method with a couple syntactic options:

I'm opting for the more traditiona invocation since that seems to match the style of inheritance
I'm currently using:

CrystalCollector.prototype.reset = function() {
  Game.prototype.reset.call(this); // :-) call superclass reset() method
  for (let index in this.crystals) {
    this.crystals[index].reset();
  }
  this.targetValue = this.getRandomValue();
};

While I'm at it, I'll update the readme with this interesting tale since it amounted to a bug
I encountered during integration testing.